### PR TITLE
Generic macOS Installer Script

### DIFF
--- a/Bash/InstallHuntress-macOS-bash.sh
+++ b/Bash/InstallHuntress-macOS-bash.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# Copyright (c) 2022 Huntress Labs, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#    * Neither the name of the Huntress Labs nor the names of its contributors
+#      may be used to endorse or promote products derived from this software
+#      without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL HUNTRESS LABS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+# The Huntress installer needs an Account Key and an Organization Key (a user
+# specified name or description) which is used to affiliate an Agent with a
+# specific Organization within the Huntress Partner's Account. These keys can be
+# hard coded below or passed in when the script is run.
+
+# For more details, see our KB article
+# https://support.huntress.io/hc/en-us/articles/4404005189011-Installing-the-Huntress-Agent
+
+
+##############################################################################
+## Begin user modified variables
+##############################################################################
+
+
+# Replace __ACCOUNT_KEY__ with your account secret key (from your Huntress portal's "download agent" section)
+defaultAccountKey="__ACCOUNT_KEY__"
+
+# If you have a preferred "placeholder" organization name for Mac agents, you can set that below.
+# Otherwise, provide the appropriate Organization Key when running the script in Atera.
+defaultOrgKey="Mac Agents"
+
+# Put the name of your RMM below. This helps our support team understand which RMM tools
+# are being used to deploy the Huntress macOS Agent. Simply replace the text in quotes below.
+rmm="Unspecified RMM"
+
+##############################################################################
+## Do not modify anything below this line
+##############################################################################
+dd=$(date "+%Y%m%d-%H%M%S")
+log_file="/tmp/HuntressInstaller.log"
+install_script="/tmp/HuntressMacInstall.sh"
+invalid_key="Invalid account secret key"
+pattern="[a-f0-9]{32}"
+version="1.0"
+
+## Using logger function to provide helpful logs within RMM tools in addition to log file
+logger() {
+    echo "$dd -- $*";
+    echo "$dd -- $*" >> $log_file;
+}
+
+# Check for root
+if [ $EUID -ne 0 ]; then
+    logger "This script must be run as root, exiting..."
+    exit 1
+fi
+
+# Clean up any old installer scripts.
+if [ -f "$install_script" ]; then
+    logger "Installer file present in /tmp; deleting."
+    rm -f "$install_script"
+fi
+
+##
+## This section handles the assigning `=` character for options.
+## Since most RMMs treat spaces as delimiters in Mac Scripting,
+## we have to use `=` to assign the option value, but must remove
+## it because, well, bash. https://stackoverflow.com/a/28466267/519360
+##
+
+usage() {
+    cat <<EOF
+Usage: $0 [options...] --account_key=<account_key> --organization_key=<organization_key>
+
+-a, --account_key      <account_key>      The account key to use for this agent install
+-o, --organization_key <organization_key> The org key to use for this agent install
+-h, --help                                Print this message
+
+EOF
+}
+
+while getopts a:o:h:-: OPT; do
+  if [ "$OPT" = "-" ]; then
+    OPT="${OPTARG%%=*}"       # extract long option name
+    OPTARG="${OPTARG#$OPT}"   # extract long option argument (may be empty)
+    OPTARG="${OPTARG#=}"      # if long option argument, remove assigning `=`
+  else
+    # the user used a short option, but we still want to strip the assigning `=`
+    OPTARG="${OPTARG#=}"      # if long option argument, remove assigning `=`
+  fi
+  case "$OPT" in
+    a | account_key)
+        account_key="$OPTARG"
+        ;;
+    o | organization_key)
+        organization_key="$OPTARG"
+        ;;
+    h | help)
+        usage
+        ;;
+    ??*)
+        logger "Illegal option --$OPT"
+        exit 2
+        ;;  # bad long option
+    \? )
+        exit 2
+        ;;  # bad short option (error reported via getopts)
+  esac
+done
+shift $((OPTIND-1)) # remove parsed options and args from $@ list
+
+logger "=========== INSTALL START AT $dd ==============="
+logger "=========== $rmm Deployment Script | Version: $version ==============="
+
+# VALIDATE OPTIONS PASSED TO SCRIPT
+if [ -z "$organization_key" ]; then
+    organizationKey=$(echo "$defaultOrgKey" | xargs)
+    logger "--organization_key parameter not present, using defaultOrgKey instead: $defaultOrgKey"
+  else
+    organizationKey=$(echo "$organization_key" | xargs)
+    logger "--organization_key parameter present, set to: $organizationKey"
+fi
+
+if ! [[ "$account_key" =~ $pattern ]]; then
+    logger "Invalid --account_key provided, checking defaultAccountKey..."
+    accountKey=$(echo "$defaultAccountKey" | xargs)
+    if ! [[ $accountKey =~ $pattern ]]; then
+        logger "ERROR: Invalid --account_key. Please check Huntress support documentation."
+        exit 1
+    fi
+    else
+        accountKey=$(echo "$account_key" | xargs)
+fi
+
+# OPTIONS REQUIRED
+if [ -z "$accountKey" ] || [ -z "$organizationKey" ]
+then
+    logger "Error: --account_key and --organization_key are both required" >> $log_file
+    echo
+    usage
+    exit 1
+fi
+
+# Hide most of the account key in the logs, keeping the front and tail end for troubleshooting 
+masked="$(echo "${accountKey:0:4}")"
+masked+="************************"
+masked+="$(echo "${accountKey: (-4)}")"
+
+logger "Provided Huntress key: $masked"
+logger "Provided Organization Key: $organizationKey"
+
+result=$(curl -w "%{http_code}" -L "https://huntress.io/script/darwin/$accountKey" -o "$install_script")
+
+if [ $? != "0" ]; then
+   logger "ERROR: Download failed with error: $result"
+   exit 1
+fi
+
+if grep -Fq "$invalid_key" "$install_script"; then
+   logger "ERROR: --account_key is invalid. You entered: $accountKey"
+   exit 1
+fi
+
+install_result="$(/bin/bash "$install_script" -a "$accountKey" -o "$organizationKey" -v)"
+logger "=============== Begin Installer Logs ==============="
+
+if [ $? != "0" ]; then
+    logger "Installer Error: $install_result"
+    exit 1
+fi
+
+logger "$install_result"
+logger "=========== INSTALL FINISHED AT $dd ==============="
+exit

--- a/Bash/InstallHuntress-macOS-bash.sh
+++ b/Bash/InstallHuntress-macOS-bash.sh
@@ -44,7 +44,7 @@
 defaultAccountKey="__ACCOUNT_KEY__"
 
 # If you have a preferred "placeholder" organization name for Mac agents, you can set that below.
-# Otherwise, provide the appropriate Organization Key when running the script in Atera.
+# Otherwise, provide the appropriate Organization Key when running the script in your RMM.
 defaultOrgKey="Mac Agents"
 
 # Put the name of your RMM below. This helps our support team understand which RMM tools

--- a/Bash/README.md
+++ b/Bash/README.md
@@ -1,0 +1,13 @@
+### Installing the Huntress macOS Agent
+
+This script is meant to be a generic tool for deploying the Huntress macOS agent with any tool that supports bash (or shell) scripting.
+
+### Required Values
+
+On lines 44 and 48 you will see `defaultAccountKey` and `defaultOrgKey` that need to be updated. The [Account Key](https://support.huntress.io/hc/en-us/articles/4404012734227#account-key) is located in your Huntress Portal. This value is used to associate the agent with your tenant. The [Organization Key](https://support.huntress.io/hc/en-us/articles/4404012734227#organization-keys) is used to organizations agents by customer within your portal. You can replace the provided `"Mac Agents"` value in the script with your customer name whem you run the script (spaces are permitted if you keep the name in double quotes), or you may simply [move the agents](https://support.huntress.io/hc/en-us/articles/4404012577299-Moving-Agents-Between-Organizations) to the appropriate organization after installation. 
+
+### Optional Value
+
+On line 52 you'll notice a value for `RMM`. This optional value allows  you to name the tool you're using to install the Huntress macOS agent, which may be helpful for our support team when troubleshooting. The value there is written to the `/tmp/HuntressInstaller.log` log file during installation and is not automatically sent to Huntress.
+
+**NOTE**: Please do not modify anything below line 52. 

--- a/Bash/README.md
+++ b/Bash/README.md
@@ -1,13 +1,48 @@
-### Installing the Huntress macOS Agent
+## Installing the Huntress macOS Agent
 
-This script is meant to be a generic tool for deploying the Huntress macOS agent with any tool that supports bash (or shell) scripting.
+This script is meant to be a generic script for deploying the Huntress macOS agent with any tool that supports bash (or shell) scripting.
 
 ### Required Values
 
-On lines 44 and 48 you will see `defaultAccountKey` and `defaultOrgKey` that need to be updated. The [Account Key](https://support.huntress.io/hc/en-us/articles/4404012734227#account-key) is located in your Huntress Portal. This value is used to associate the agent with your tenant. The [Organization Key](https://support.huntress.io/hc/en-us/articles/4404012734227#organization-keys) is used to organizations agents by customer within your portal. You can replace the provided `"Mac Agents"` value in the script with your customer name whem you run the script (spaces are permitted if you keep the name in double quotes), or you may simply [move the agents](https://support.huntress.io/hc/en-us/articles/4404012577299-Moving-Agents-Between-Organizations) to the appropriate organization after installation. 
+On lines 44 and 48 you will see two variables (`defaultAccountKey` and `defaultOrgKey`) that need to be updated. The [Account Key](https://support.huntress.io/hc/en-us/articles/4404012734227#account-key) is located in your Huntress Portal. This value is used to associate the agent with your tenant. The [Organization Key](https://support.huntress.io/hc/en-us/articles/4404012734227#organization-keys) is used to organizations agents by customer within your portal. You can replace the provided `"Mac Agents"` value in the script with your customer name whem you run the script (spaces are permitted if you keep the name in double quotes), or you may simply [move the agents](https://support.huntress.io/hc/en-us/articles/4404012577299-Moving-Agents-Between-Organizations) to the appropriate organization after installation. 
 
 ### Optional Value
 
 On line 52 you'll notice a value for `RMM`. This optional value allows  you to name the tool you're using to install the Huntress macOS agent, which may be helpful for our support team when troubleshooting. The value there is written to the `/tmp/HuntressInstaller.log` log file during installation and is not automatically sent to Huntress.
 
-**NOTE**: Please do not modify anything below line 52. 
+**NOTE**: Please do not modify anything below line 52.
+
+
+### Running from command line with arguments
+
+Some tools don't have a scripting engine, but will permit you to upload a script and pass parameters to it. If you need to run this as a script with parameters, simply follow the guidelines below:
+
+```
+-a, --account_key      <account_key>      The account key to use for this agent install
+-o, --organization_key <organization_key> The org key to use for this agent install
+```
+
+As noted above, there are two required fields that can be defined statically in the script, or you can pass the values as parameters. The `organization_key` parameter supports strings, so if you pass `My Company`, just be sure to put it in double quotes like so: `"My Company"`
+
+Example usage:
+
+`./InstallHuntress-macOS-bash.sh --account_key 123456abcdef --organization_key "My Awesome Coffee Shop"`
+
+### Logging and Troubleshooting
+
+The installer log is located in `/tmp/HuntressInstaller.log` and the output of a successful install would look like:
+
+```
+20221103-085511 -- =========== INSTALL START AT 20221103-085511 ===============
+20221103-085511 -- =========== Syncro macOS deployment component | Version: 1.0 ===============
+20221103-085511 -- --organization_key parameter present, set to: My Awesome Coffee Shop
+20221103-085511 -- Provided Huntress key: 1234************************cdef
+20221103-085511 -- Provided Organization Key: My Awesome Coffee Shop
+20221103-085511 -- =============== Begin Installer Logs ===============
+20221103-085511 -- creating /tmp/hagent.yaml...
+running the installer...
+installer: Package name is Huntress Agent
+installer: Upgrading at base path /
+installer: The upgrade was successful.
+cleaning up...
+20221103-085511 -- =========== INSTALL FINISHED AT 20221103-085511 ===============


### PR DESCRIPTION
This PR is to provide a generic bash installer for macOS that can be used in RMMs where we don't have explicit documentation. This script is based on the same script used for the RMMs, with some slight modifications to make it easier for partners to use.