### PR TITLE
Updated to correctly handle if TAGS are hardcoded in script

### DIFF
--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -322,9 +322,7 @@ function Install-Huntress ($OrganizationKey) {
     LogMessage $msg
 
     # if $Tags value exists install using the provided tags, then check hardcoded, then set no tags
-    if ($Tags) {
-        $process = Start-Process $InstallerPath "/ACCT_KEY=`"$AccountKey`" /ORG_KEY=`"$OrganizationKey`" /TAGS=`"$TagsKey`" /S" -PassThru
-    } elseif ($TagsKey -ne "__TAGS__") {
+    if (($Tags) -or ($TagsKey -ne "__TAGS__")) {
         $process = Start-Process $InstallerPath "/ACCT_KEY=`"$AccountKey`" /ORG_KEY=`"$OrganizationKey`" /TAGS=`"$TagsKey`" /S" -PassThru
     } else {
         $process = Start-Process $InstallerPath "/ACCT_KEY=`"$AccountKey`" /ORG_KEY=`"$OrganizationKey`" /S" -PassThru

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -320,9 +320,11 @@ function Install-Huntress ($OrganizationKey) {
     # execute the installer, stopping if it gets hung (security product interference)
     $msg = "Executing installer..."
     LogMessage $msg
-    
-    # if $Tags value exists install using the provided tags, otherwise no tags
+
+    # if $Tags value exists install using the provided tags, then check hardcoded, then set no tags
     if ($Tags) {
+        $process = Start-Process $InstallerPath "/ACCT_KEY=`"$AccountKey`" /ORG_KEY=`"$OrganizationKey`" /TAGS=`"$TagsKey`" /S" -PassThru
+    } elseif ($TagsKey -ne "__TAGS__") {
         $process = Start-Process $InstallerPath "/ACCT_KEY=`"$AccountKey`" /ORG_KEY=`"$OrganizationKey`" /TAGS=`"$TagsKey`" /S" -PassThru
     } else {
         $process = Start-Process $InstallerPath "/ACCT_KEY=`"$AccountKey`" /ORG_KEY=`"$OrganizationKey`" /S" -PassThru


### PR DESCRIPTION
We had a bit of a logic error - tags that were hardcoded in the top of the script weren't being used because we were always checking for the presence of tags passed in as an arg, then if they weren't we were skipping the tags. This should fix it.