### PR TITLE
fix line endings

### DIFF
--- a/Atera/.gitattributes
+++ b/Atera/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Now that we provide scripts for macOS and Windows, line endings are important to consider given the variety of ways that users obtain and utilize our scripts within RMM tools.

The issue was uncovered during a support interaction, and validated from [this](https://stackoverflow.com/questions/39527571/are-shell-scripts-sensitive-to-encoding-and-line-endings) helpful post.