### PR TITLE
Bug/sc 85380 powershell script for install if errors writes

### DIFF
--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -805,7 +805,7 @@ function copyLogAndExit {
     Start-Sleep 1
     $agentPath = getAgentPath
     $logLocation = Join-Path $agentPath "HuntressPoShInstaller.log"
-    Copy-Item -Path $DebugLog -Destination $agentPath -Force
+    Copy-Item -Path $DebugLog -Destination $logLocation -Force
     Write-Output "$($DebugLog) copied to $(getAgentPath)"
     Write-Output "Script complete"
     exit 0

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -805,8 +805,9 @@ function copyLogAndExit {
     Start-Sleep 1
     $agentPath = getAgentPath
     $logLocation = Join-Path $agentPath "HuntressPoShInstaller.log"
+    if (!(Test-Path -path $agentPath)) {New-Item $agentPath -Type Directory}
     Copy-Item -Path $DebugLog -Destination $logLocation -Force
-    Write-Output "$($DebugLog) copied to $(getAgentPath)"
+    Write-Output "$($DebugLog) copied to $agentPath"
     Write-Output "Script complete"
     exit 0
 }

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -782,7 +782,7 @@ function logInfo {
         try {
             $secureChannelStatus = Test-ComputerSecureChannel
         } catch {
-            LogMessage "Warning, unable to Test-ComputerSeccureChannel. If this isn't a DC, then the trust relationship wiht DC may be broken"
+            LogMessage "Warning, unable to Test-ComputerSecureChannel. If this isn't a DC, then the trust relationship with the DC may be broken"
             $secureChannelStatus = $false
         }
         if ( ! $secureChannelStatus) {
@@ -803,10 +803,10 @@ function logInfo {
 # In the past we copied to the users temp folder, difficult to find on machines with lots of profiles. Solved this by always placing the log in the normal Huntress folder.
 function copyLogAndExit {
     Start-Sleep 1
-    $logLocation = $DebugLog
-    $agentPath   = getAgentPath
-    Copy-Item -Path $logLocation -Destination $agentPath -Force
-    Write-Output "$($Debuglog) copied to $(getAgentPath)"
+    $agentPath = getAgentPath
+    $logLocation = Join-Path $agentPath "HuntressPoShInstaller.log"
+    Copy-Item -Path $DebugLog -Destination $agentPath -Force
+    Write-Output "$($DebugLog) copied to $(getAgentPath)"
     Write-Output "Script complete"
     exit 0
 }

--- a/Powershell/README.md
+++ b/Powershell/README.md
@@ -2,7 +2,7 @@
 
 This PowerShell script will install the Huntress Agent. The script will automatically download the installer from the Huntress servers and run it. The script does error checking and logging as well. (It will check to see if the agent is already installed and also verfiy the installation completed.)
 
-You have the option to hard code your Huntress account key, organization key, and tags (optional) in the script, or pass as arguments to the script. [Click here for more details regarding the Account Key and Organization Key.](https://support.huntress.io/article/7-using-account-and-organization-keys)
+You have the option to hard code your Huntress account key, organization key, and tags (optional) in the script, or pass as arguments to the script. [Click here for more details regarding the Account Key and Organization Key.](https://support.huntress.io/hc/en-us/articles/4404012734227-Using-Account-Keys-Organization-Keys-and-Agent-Tags)
 
 The script supports the following mutually exclusive command-line switches:
 * `-reregister` - Force the agent to re-register (useful for clean install)


### PR DESCRIPTION
- Added more error handling around some of the configuration checks to prevent the script from completely breaking
- Fixed the issue where the log was being dropped into a file named "Huntress" as a name instead of being placed into a subdirectory in the Huntress directory.