### PR TITLE
fix testAdministrator test for local admin

### DIFF
--- a/N-able (SolarWinds) N-central/powershell/InstallHuntress.powershellv2.ps1
+++ b/N-able (SolarWinds) N-central/powershell/InstallHuntress.powershellv2.ps1
@@ -476,8 +476,8 @@ function isOrphan {
 
 # Check if the script is being run with admin access AB
 function testAdministrator {
-    $user = [Security.Principal.WindowsIdentity]::GetCurrent();
-    (New-Object Security.Principal.WindowsPrincipal $user).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+    $user = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent());
+    $user.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator);
 }
 
 # Ensure the disk has enough space for the install files + agent, then write results to the log AB

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -475,9 +475,9 @@ function isOrphan {
 }
 
 # Check if the script is being run with admin access AB
-function testAdministrator {  
-    $user = [Security.Principal.WindowsIdentity]::GetCurrent();
-    (New-Object Security.Principal.WindowsPrincipal $user).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)  
+function testAdministrator {
+    $user = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent());
+    $user.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator);
 }
 
 # Ensure the disk has enough space for the install files + agent, then write results to the log AB


### PR DESCRIPTION
When testing locally I found a bug where the `testAdministrator` method passed even when not running in an elevated PowerShell window. Upon further digging, it appears this check was arranged incorrectly.

**Possible enhancement request**: could we add this check as a requirement to run the script? A few possible options include adding this block at the top of the script ([requires](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7.3#-runasadministrator) PowerShell v4.0 or higher):
```
#Requires -RunAsAdministrator
```

Or simply adding the `testAdministrator` function to the flow of the script _rather than_ simply checking it for logging.