### PR TITLE
Compatibility with legacy machines

### DIFF
--- a/ConnectWise-Automate/staged/InstallHuntress.automate.ps1
+++ b/ConnectWise-Automate/staged/InstallHuntress.automate.ps1
@@ -182,11 +182,10 @@ function Get-Installer {
 
     # Ensure a secure TLS version is used.
     $ProtocolsSupported = [enum]::GetValues('Net.SecurityProtocolType')
-    if ( ($ProtocolsSupported -contains 'Tls13') -and ($ProtocolsSupported -contains 'Tls12') ){
-        # Use only TLS 1.3 or 1.2
-        LogMessage "Using TLS 1.3 or 1.2..."
+    LogMessage $ProtocolsSupported
+    if ( $ProtocolsSupported -contains 'Tls13' ){
+        LogMessage "Using TLS 1.3"
         [Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 12288)
-        [Net.ServicePointManager]::SecurityProtocol += [Enum]::ToObject([Net.SecurityProtocolType], 3072)
     } else {
         LogMessage "Using TLS 1.2..."
         try {


### PR DESCRIPTION
Older versions of PoSh do not support SecurityProtocol addition and throw a op_Addition error. Forcing the machine to chose either TLS 1.3 or 1.2 appears to solve this. See ticket 56532