### PR TITLE
Increased compatibility with legacy OS

### DIFF
--- a/ConnectWise-Automate/staged/InstallHuntress.automate.ps1
+++ b/ConnectWise-Automate/staged/InstallHuntress.automate.ps1
@@ -183,16 +183,14 @@ function Get-Installer {
     # Ensure a secure TLS version is used.
     $ProtocolsSupported = [enum]::GetValues('Net.SecurityProtocolType')
     if ( ($ProtocolsSupported -contains 'Tls13') -and ($ProtocolsSupported -contains 'Tls12') ){
-        # Use only TLS 1.3 or 1.2
         LogMessage "Using TLS 1.3 or 1.2..."
-        [Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 12288)
-        [Net.ServicePointManager]::SecurityProtocol += [Enum]::ToObject([Net.SecurityProtocolType], 3072)
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12 -bor [System.Net.SecurityProtocolType]::Tls13
     } else {
         LogMessage "Using TLS 1.2..."
         try {
             # In certain .NET 4.0 patch levels, SecurityProtocolType does not have a TLS 1.2 entry.
             # Rather than check for 'Tls12', we force-set TLS 1.2 and catch the error if it's truly unsupported.
-            [Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
+            [Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
         } catch {
             $msg = $_.Exception.Message
             $err = "ERROR: Unable to use a secure version of TLS. Please verify Hotfix KB3140245 is installed."

--- a/ConnectWise-Automate/staged/InstallHuntress.automate.ps1
+++ b/ConnectWise-Automate/staged/InstallHuntress.automate.ps1
@@ -60,7 +60,7 @@ Set-StrictMode -Version Latest
 
 # Do not modify the following variables.
 # These are used by the Huntress support team when troubleshooting.
-$ScriptVersion = "Version 2, major revision 7, 2023 May 1"
+$ScriptVersion = "Version 2, major revision 7, 2023 June 21"
 $ScriptType = "Automate"
 
 # Check for an account key specified on the command line.


### PR DESCRIPTION
Older versions of PoSh didn't support this additive operation [Net.ServicePointManager]::SecurityProtocol += .... So switching to the more compatible binary OR operator (tested as far back as PoSh 2.0) Also cleaned up the protocol assignment to use the actual ENUM instead of the number to make it easier to read