### PR TITLE
Made runProcess errors more descriptive

### DIFF
--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -578,6 +578,7 @@ function runProcess ($process, $flags, $name){
         }
 
         $err = "ERROR: $($name) running as '$($process) $($flags)' failed to complete in $timeout seconds, full error message: '$($msg).'"
+        Write-Host $err -ForegroundColor white -BackgroundColor red
         LogMessage $err
         copyLogAndExit
     }


### PR DESCRIPTION
### Fixes made

Run process was always printing a timeout error, even if the cause wasn't a timeout. That's been fixed so that more detailed errors are returned.

We're also separately grabbing the process object now in order to be able to properly kill it - this ensures we always kill the right process, not a process that just luckily has the same name. This removes the edge case that multiple instances of the install huntress script are running on the same host at the same time. 

The new message looks as follows depending on the error:
```
ERROR: Ping process running as 'ping.exe -n 200 google.com' failed to complete in 5 seconds, full error message: 'This command stopped operation because process "PING (9428)" is not stopped in the specified time-out..'
ERROR: Non-existent EXE for process running as 'blah.exe -n 200 google.com' failed to complete in 5 seconds, full error message: 'This command cannot be run due to the error: The system cannot find the file specified..'
```


### More help is needed to update the other RMM scripts using this powershell