### PR TITLE
Don't copy the log on uninstall

### DIFF
--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -222,8 +222,9 @@ function KillProcessByName {
     )
 
     $processes = Get-Process | Where-Object { $_.ProcessName -eq $ProcessName }
+    $processCount = $processes | Measure-Object | Select-Object -ExpandProperty Count
 
-    if ($processes.Count -eq 0) {
+    if ($processCount -eq 0) {
         LogMessage "No processes with the name '$ProcessName' are currently running."
     }
     else {


### PR DESCRIPTION
We're currently trying to copy the debug log to the Huntress folder on uninstall. Stop doing that!

Also added a force kill on the process exe's after we stop the service to make sure they exit before we try to run the uninstallers.