### PR TITLE
Retry error downloading Huntress Installer

### DIFF
--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -318,6 +318,13 @@ function Get-Installer {
         }
     }
 
+    # Delete stale installer before downloading the most recent installer
+    if (Test-Path $InstallerPath -PathType Leaf) {
+        $err = "WARNING: '$InstallerPath' already exists, deleting stale Huntress Installer."
+        LogMessage $err
+        Remove-Item -Path $InstallerPath -Force -ErrorAction SilentlyContinue
+    }
+
     # Attempt to download the correct installer for the given OS, retry if it fails
     $attempts = 6
     $delay = 60

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -70,7 +70,7 @@ $estimatedSpaceNeeded = 200111222
 ##############################################################################
 
 # These are used by the Huntress support team when troubleshooting.
-$ScriptVersion = "Version 2, major revision 7, 2024 January 8"
+$ScriptVersion = "Version 2, major revision 7, 2024 January 23"
 $ScriptType = "PowerShell"
 
 # variables used throughout this script


### PR DESCRIPTION
This PR introduces a delayed retry when downloading the Huntress Installer fails, and prevents a path conflict by deleting the previous Huntress Installer if it already exists.