### PR TITLE
Updating Script version

### DIFF
--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -70,7 +70,7 @@ $estimatedSpaceNeeded = 200111222
 ##############################################################################
 
 # These are used by the Huntress support team when troubleshooting.
-$ScriptVersion = "Version 2, major revision 7, 2024 January 24"
+$ScriptVersion = "Version 2, major revision 7, 2024 April 16"
 $ScriptType = "PowerShell"
 
 # variables used throughout this script


### PR DESCRIPTION
This script version should be kept up to date as Support uses it to confirm which version of our script partners are using. It's vital for troubleshooting.