### PR TITLE
feat: [sc-135315] Update macOS deployment script for Intune

### DIFF
--- a/Bash/InstallHuntress-macOS-bash.sh
+++ b/Bash/InstallHuntress-macOS-bash.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Copyright (c) 2024 Huntress Labs, Inc.
 # All rights reserved.


### PR DESCRIPTION
Story details: https://app.shortcut.com/huntress/story/135315
use `/usr/bin/env zsh` instead of `/bin/zsh`.
microsoft no likey the latter: https://learn.microsoft.com/en-us/mem/intune/apps/macos-shell-scripts