### PR TITLE
Add policy path to the log. helpful when the deployment fails

### DIFF
--- a/Addigy/InstallHuntress-macOS-Addigy.sh
+++ b/Addigy/InstallHuntress-macOS-Addigy.sh
@@ -97,7 +97,7 @@ if [ -f "$install_script" ]; then
     rm -f "$install_script"
 fi
 
-# Log policy path if Addigy policies are being used to help in troubleshooting
+# Log policy path if Addigy policies are being. Useful for troubleshooting
 if [ -n "$topLevelPolicy" ]; then
     logger "Policy Path: ${POLICY_PATH}"
     logger "Policy Path (base64): $(echo ${POLICY_PATH} | base64)"

--- a/Addigy/InstallHuntress-macOS-Addigy.sh
+++ b/Addigy/InstallHuntress-macOS-Addigy.sh
@@ -101,6 +101,7 @@ fi
 if [ -n "$topLevelPolicy" ]; then
     logger "Policy Path: ${POLICY_PATH}"
     logger "Policy Path (base64): $(echo ${POLICY_PATH} | base64)"
+    logger "Top Level Policy: $topLevelPolicy"
 fi
 
 ##

--- a/Addigy/InstallHuntress-macOS-Addigy.sh
+++ b/Addigy/InstallHuntress-macOS-Addigy.sh
@@ -97,6 +97,12 @@ if [ -f "$install_script" ]; then
     rm -f "$install_script"
 fi
 
+# Log policy path if Addigy policies are being used to help in troubleshooting
+if [ -n "$topLevelPolicy" ]; then
+    logger "Policy Path: ${POLICY_PATH}"
+    logger "Policy Path (base64): $(echo ${POLICY_PATH} | base64)"
+fi
+
 ##
 ## This section handles the assigning `=` character for options.
 ## Since most RMMs treat spaces as delimiters in Mac Scripting,


### PR DESCRIPTION
A quick change to Addigy deployment script to log the `POLICY_PATH`.
We see a couple tickets about this and it's not clear where the problem is. 
Having the `POLICY_PATH` printed to the logs would help discern what's going wrong quicker.