### PR TITLE
Fix deployment script to accept multiple [sc-136060]

### DIFF
--- a/Addigy/InstallHuntress-macOS-Addigy.sh
+++ b/Addigy/InstallHuntress-macOS-Addigy.sh
@@ -204,11 +204,11 @@ if grep -Fq "$invalid_key" "$install_script"; then
    exit 1
 fi
 
-install_cmd="/bin/zsh $install_script -a $accountKey -o $organizationKey -v"
 if [ "$install_system_extension" = true ]; then
-    install_cmd+=" --install_system_extension"
+    install_result="$(/bin/bash "$install_script" -a "$accountKey" -o "$organizationKey" -v --install_system_extension)"
+else
+    install_result="$(/bin/bash "$install_script" -a "$accountKey" -o "$organizationKey" -v)"
 fi
-install_result=$(eval "${install_cmd}")
 
 logger "=============== Begin Installer Logs ==============="
 

--- a/Addigy/InstallHuntress-macOS-Addigy.sh
+++ b/Addigy/InstallHuntress-macOS-Addigy.sh
@@ -204,13 +204,12 @@ if grep -Fq "$invalid_key" "$install_script"; then
    exit 1
 fi
 
+logger "=============== Begin Installer Logs ==============="
 if [ "$install_system_extension" = true ]; then
     install_result="$(/bin/bash "$install_script" -a "$accountKey" -o "$organizationKey" -v --install_system_extension)"
 else
     install_result="$(/bin/bash "$install_script" -a "$accountKey" -o "$organizationKey" -v)"
 fi
-
-logger "=============== Begin Installer Logs ==============="
 
 if [ $? != "0" ]; then
     logger "Installer Error: $install_result"

--- a/Bash/InstallHuntress-macOS-bash.sh
+++ b/Bash/InstallHuntress-macOS-bash.sh
@@ -185,11 +185,11 @@ if grep -Fq "$invalid_key" "$install_script"; then
    exit 1
 fi
 
-install_cmd="/bin/zsh $install_script -a $accountKey -o $organizationKey -v"
 if [ "$install_system_extension" = true ]; then
-    install_cmd+=" --install_system_extension"
+    install_result="$(/bin/bash "$install_script" -a "$accountKey" -o "$organizationKey" -v --install_system_extension)"
+else
+    install_result="$(/bin/bash "$install_script" -a "$accountKey" -o "$organizationKey" -v)"
 fi
-install_result=$(eval "${install_cmd}")
 
 logger "=============== Begin Installer Logs ==============="
 


### PR DESCRIPTION
## Problem
Effectively passing a multi word organization to the install script would break and only register the first word.
This is due to shell quoting compounded by a script calling another script.

## Fix
* Use the old way of calling scripts. 
(Note: there's probably a better way to do this, but I'm choosing not to fight *sh space/quoting/IFS issues)
* Amend Addigy logging statements, since multiple scripts end up writing to the same log.

## Testing
* Effectively comment out `curl` commands and modify the `HuntressMacInstall.sh` to exit after creating the hagent.yml
* run `POLICY_PATH="Fireline Partners | Anchor Point IT Solutions" zsh -x ./InstallHuntress-macOS-Addigy.sh`
* validate that the org name includes "Fireline Partners"

There are other files that also need to be update (Ninja, Kaseya, etc).
I intend to follow up with another PR that will address those in a similar way

![proof](https://github.com/huntresslabs/deployment-scripts/assets/106617400/c7b13103-5276-46e3-90ca-050766f944a0)
