### PR TITLE
Add a version number to human readable field

### DIFF
--- a/Bash/HuntressSystemExtensionProfile.mobileconfig
+++ b/Bash/HuntressSystemExtensionProfile.mobileconfig
@@ -134,7 +134,7 @@
 	<key>PayloadDescription</key>
 	<string>Huntress PPPC for FDA and System Extension</string>
 	<key>PayloadDisplayName</key>
-	<string>Huntress Agent with System Extension</string>
+	<string>Huntress Agent with System Extension v2</string>
 	<key>PayloadIdentifier</key>
 	<string>com.huntress.app</string>
 	<key>PayloadOrganization</key>

--- a/Bash/README.md
+++ b/Bash/README.md
@@ -55,6 +55,8 @@ The `mobileconfig` file in this directory contains preconfigured settings for MD
 
 `HuntressSystemExtension.mobileconfig` grants all the permissions required by the Huntress Agent and the Huntress System Extension. It enables FDA (full disk access) for both and provides the System Extension with the neccessary permissions for install and operation. Most partners will use this set of configurations.
 
+The mobileconfig file is suffixed with a version number (as of Nov 2024), which will be updated when changes are made to it.
+
 ## Legacy Mobileconfigs
 
 These are kept around for historical reasons in the `legacy-mobileconfigs` folder. **Do not use these these files unless you are specifically directed to by Huntress Support**


### PR DESCRIPTION
The mobileconfigs are indistinguishable from a previous version if updated, having a version number is fairly handy.
It'd help troubleshoot issues far more quickly.

While the filename is the same, the UI display would reflect this in
1. **System Settings** -> **Device Management**
  ![image](https://github.com/user-attachments/assets/3d33f7c0-885e-48cb-9ead-314c58793312)
2. CLI   
 ` profiles -C -o stdout-xml`

These would need to be updated when a new edition of the mobileconfig is made