### PR TITLE
check for service existence before taking action

### DIFF
--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -70,7 +70,7 @@ $estimatedSpaceNeeded = 200111222
 ##############################################################################
 
 # These are used by the Huntress support team when troubleshooting.
-$ScriptVersion = "Version 2, major revision 8, 2025 Apr 10"
+$ScriptVersion = "Version 2, major revision 8, 2025 Apr 17"
 $ScriptType = "PowerShell"
 
 # variables used throughout this script
@@ -454,23 +454,23 @@ function Test-Installation {
     }
 
     # Check for Legacy OS, any kernel below 6.2 cannot run Huntress EDR (so we skip that check)
+    $services = @($HuntressAgentServiceName, $HuntressUpdaterServiceName, $HuntressEDRServiceName)
     if ( ($KernelVersion.major -eq 6 -and $KernelVersion.minor -lt 2) -or ($KernelVersion.major -lt 6) ) {
+        LogMessage "WARNING: Legacy OS detected, Huntress EDR will not be installed"
         $services = @($HuntressAgentServiceName, $HuntressUpdaterServiceName)
-        $err = "WARNING: Legacy OS detected, Huntress EDR will not be installed"
-        LogMessage $err
     } else {
-        $services = @($HuntressAgentServiceName, $HuntressUpdaterServiceName, $HuntressEDRServiceName)
+        LogMessage "Huntress EDR will be installed automatically in < 24 hours."
     }
 
     # Ensure the services are installed and running.
     foreach ($svc in $services) {
-        # repairing previously broken Huntress install which may have set it's services to disabled (services are not removed on uninstall)
-        if ( $(Get-Service $svc).StartType -ne "automatic") {
-            LogMessage "Disabled service $svc detected, attempting to set startup type to automatic."
-            c:\Windows\System32\sc.exe config $svc start=auto
-        }
         # check if the service is installed
         if ( ! (Confirm-ServiceExists($svc))) {
+            # repairing previously broken Huntress install which may have set it's services to disabled (services are not removed on uninstall)
+            if ( $(Get-Service $svc).StartType -ne "automatic") {
+                LogMessage "Disabled service $svc detected, attempting to set startup type to automatic."
+                c:\Windows\System32\sc.exe config $svc start=auto
+            }
             # if Huntress was installed before this script started and Rio is missing then we log that, but continue with this script
             if ($svc -eq $HuntressEDRServiceName) {
                 if ($isHuntressInstalled) {
@@ -965,7 +965,8 @@ function copyLogAndExit {
 #########################################################################################
 function main () {
     # Start the script with logging as much as we can as soon as we can. All your logging are belong to us, Zero Wang.
-    logInfo
+    logInfo 
+    LogMessage "Script flags:  Reregister=$reregister  Reinstall=$reinstall  Uninstall=$uninstall  Repair=$repair"
 
     # if run with the uninstall flag, exit so we don't reinstall the agent after
     if ($uninstall) {
@@ -990,13 +991,10 @@ function main () {
         $repair = $true
     }
 
-    # if run with the repair flag, check if installed (install if not), if ver < 0.13.16 apply the fix
+    # Originally created to fix a bug, now acts as a -reregister flag if no Hunress is found
     if ($repair) {
         if (Test-Path(getAgentPath)){
             if (!(repairAgent)){
-
-            } else {
-                LogMessage "Repair complete!"
             }
             copyLogAndExit
         } else {

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -447,9 +447,12 @@ function Test-Installation {
         LogMessage ($err + $SupportMessage)
         if (Test-Path "$($HuntressDirectory)\HuntressAgent.log") {
             $linesFromLog = Get-Content "$($HuntressDirectory)\HuntressAgent.log" | Select-Object -first 4
+            LogMessage "Last 4 lines of HuntressAgent.log:"
             ForEach ($line in $linesFromLog) {
                 LogMessage $line
             }
+        } else {
+            LogMessage "HuntressAgent.log not found after post-registration failure! Likely 3rd party interference (AV/ThreatLocker). " 
         }
     }
 

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -963,7 +963,7 @@ function copyLogAndExit {
     exit 0
 }
 
-# Sometimes previous installs can be stuck with services in the Disabled state, this function attempts to set the state to Automatic. 
+# Sometimes previous installs can be stuck with services in the Disabled state, this function attempts to set the state to Automatic.
 # Services in the Disabled state cannot be manually started, and TP will stop partners from fixing this themselves. AB
 function fixServices {
     echo "Attempting to fix services"

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -452,7 +452,7 @@ function Test-Installation {
                 LogMessage $line
             }
         } else {
-            LogMessage "HuntressAgent.log not found after post-registration failure! Likely 3rd party interference (AV/ThreatLocker). " 
+            LogMessage "HuntressAgent.log not found after post-registration failure! Likely 3rd party interference (AV/ThreatLocker). "
         }
     }
 

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -966,7 +966,6 @@ function copyLogAndExit {
 # Sometimes previous installs can be stuck with services in the Disabled state, this function attempts to set the state to Automatic.
 # Services in the Disabled state cannot be manually started, and TP will stop partners from fixing this themselves. AB
 function fixServices {
-    echo "Attempting to fix services"
     # Ensure the services are installed before repairing the state
     foreach ($svc in $services) {
         if (  (Confirm-ServiceExists($svc))) {

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -452,7 +452,7 @@ function Test-Installation {
                 LogMessage $line
             }
         } else {
-            LogMessage "HuntressAgent.log not found after post-registration failure! Likely 3rd party interference (AV/ThreatLocker). "
+            LogMessage "HuntressAgent.log not found after post-registration failure! Likely 3rd party interference (AV/ThreatLocker)."
         }
     }
 

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -70,7 +70,7 @@ $estimatedSpaceNeeded = 200111222
 ##############################################################################
 
 # These are used by the Huntress support team when troubleshooting.
-$ScriptVersion = "Version 2, major revision 8, 2025 Apr 17"
+$ScriptVersion = "Version 2, major revision 8, 2025 Apr 18"
 $ScriptType = "PowerShell"
 
 # variables used throughout this script
@@ -470,11 +470,6 @@ function Test-Installation {
     foreach ($svc in $services) {
         # check if the service is installed
         if ( ! (Confirm-ServiceExists($svc))) {
-            # repairing previously broken Huntress install which may have set it's services to disabled (services are not removed on uninstall)
-            if ( $(Get-Service $svc).StartType -ne "automatic") {
-                LogMessage "Disabled service $svc detected, attempting to set startup type to automatic."
-                c:\Windows\System32\sc.exe config $svc start=auto
-            }
             # if Huntress was installed before this script started and Rio is missing then we log that, but continue with this script
             if ($svc -eq $HuntressEDRServiceName) {
                 if ($isHuntressInstalled) {

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -965,7 +965,7 @@ function copyLogAndExit {
 #########################################################################################
 function main () {
     # Start the script with logging as much as we can as soon as we can. All your logging are belong to us, Zero Wang.
-    logInfo 
+    logInfo
     LogMessage "Script flags:  Reregister=$reregister  Reinstall=$reinstall  Uninstall=$uninstall  Repair=$repair"
 
     # if run with the uninstall flag, exit so we don't reinstall the agent after

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -475,11 +475,6 @@ function Test-Installation {
     foreach ($svc in $services) {
         # check if the service is installed
         if ( ! (Confirm-ServiceExists($svc))) {
-            # repairing previously broken Huntress install which may have set it's services to disabled (services are not removed on uninstall)
-            if ( $(Get-Service $svc).StartType -ne "automatic") {
-                LogMessage "Disabled service $svc detected, attempting to set startup type to automatic."
-                c:\Windows\System32\sc.exe config $svc start=auto
-            }
             # if Huntress was installed before this script started and Rio is missing then we log that, but continue with this script
             if ($svc -eq $HuntressEDRServiceName) {
                 if ($isHuntressInstalled) {


### PR DESCRIPTION
-Post install service repair for previous Huntress installs with services stuck in the stopped state, now checks that the service exists before proceeding with repair. 
-Logging added: show what flags the script was run with
-Removed some unused parts of a repair function we no longer need, done so partners who use the flag don't see a false message about repair being complete. Currently it acts as a -reregister flag only, but saving for potential future use.