### PR TITLE
Fix Early Exit caused by Folder Detection

### DIFF
--- a/Datto-RMM/scripts/InstallHuntress.dattormm.comstore.ps1
+++ b/Datto-RMM/scripts/InstallHuntress.dattormm.comstore.ps1
@@ -1065,7 +1065,8 @@ function main () {
     } else {
         LogMessage "Checking for HuntressAgent install..."
         $agentPath = getAgentPath
-        if ( (Test-Path $agentPath) -eq $true) {
+        $agentExe = Join-Path $agentPath "HuntressAgent.exe"
+        if ( (Test-Path $agentExe) -eq $true) {
             LogMessage "The Huntress Agent is already installed in $agentPath. Exiting with no changes. Suggest using -reregister or -reinstall flags"
             copyLogAndExit
         }

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -1053,7 +1053,7 @@ function main () {
         StopHuntressServices
     } else {
         LogMessage "Checking for HuntressAgent install..."
-        $agentPath = getAgentPath
+        $agentExe = Join-Path $agentPath "HuntressAgent.exe"
         if ( (Test-Path $agentPath) -eq $true) {
             LogMessage "The Huntress Agent is already installed in $agentPath. Exiting with no changes. Suggest using -reregister or -reinstall flags"
             copyLogAndExit

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -1053,8 +1053,9 @@ function main () {
         StopHuntressServices
     } else {
         LogMessage "Checking for HuntressAgent install..."
+        $agentPath = getAgentPath
         $agentExe = Join-Path $agentPath "HuntressAgent.exe"
-        if ( (Test-Path $agentPath) -eq $true) {
+        if ( (Test-Path $agentExe) -eq $true) {
             LogMessage "The Huntress Agent is already installed in $agentPath. Exiting with no changes. Suggest using -reregister or -reinstall flags"
             copyLogAndExit
         }


### PR DESCRIPTION
If the huntress installer script fails, it will leave a log file in the Huntress folder. If you run the job again, it will exit early as it has 'detected' that huntress was already installed since the folder exists.

Instead, it should check if the executable is there.

Additionally, there are multiple checks that happen before this which does confirm if Huntress is already installed, so I don't think this one is really needed. However, it does give extra output saying to use re-register or reinstall flags.