### PR TITLE
Fix poor service detection

### DIFF
--- a/Datto-RMM/scripts/InstallHuntress.dattormm.comstore.ps1
+++ b/Datto-RMM/scripts/InstallHuntress.dattormm.comstore.ps1
@@ -726,7 +726,7 @@ function uninstallHuntress {
     # if Huntress services still exist, then delete
     $services = @("HuntressRio", "HuntressAgent", "HuntressUpdater", "Huntmon")
     foreach ($service in $services) {
-        if ( $service ) {
+        if (Confirm-ServiceExists $service) {
             LogMessage "Service $($service) detected post uninstall, attempting to remove"
             c:\Windows\System32\sc.exe STOP $service
             c:\Windows\System32\sc.exe DELETE $service

--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -722,7 +722,7 @@ function uninstallHuntress {
     # if Huntress services still exist, then delete
     $services = @("HuntressRio", "HuntressAgent", "HuntressUpdater", "Huntmon")
     foreach ($service in $services) {
-        if ( $service ) {
+        if (Confirm-ServiceExists $service) {
             LogMessage "Service $($service) detected post uninstall, attempting to remove"
             c:\Windows\System32\sc.exe STOP $service
             c:\Windows\System32\sc.exe DELETE $service


### PR DESCRIPTION
Currently, when attempting to uninstall or reinstall the Huntress service, it will run the service uninstall / delete commands even if the service does not exist. This is because there is no detection method to see if the services are active.

![image](https://github.com/user-attachments/assets/95ea43d5-28d6-4f1a-a159-96e5443406ce)
