### PR TITLE
Update sysext fact script to handle new status command

### DIFF
--- a/Addigy/facts/sysext.sh
+++ b/Addigy/facts/sysext.sh
@@ -1,24 +1,68 @@
 #!/bin/zsh
-output=$(/Applications/Huntress.app/Contents/MacOS/Huntress extensionctl status)
 
-if [[ $output != *"Extension Status: installed"* ]]; then
-  echo "No - Extension Not Installed";
-  exit
+# Checks the system extension status for versions of the agent before 0.14.32
+check_legacy_status() {
+  output=$(/Applications/Huntress.app/Contents/MacOS/Huntress extensionctl status)
+
+  if [[ $output != *"Extension Status: installed"* ]]; then
+    echo "No - Extension Not Installed";
+    exit
+  fi
+
+  if [[ $output != *"Full Disk Access for Extension: enabled"* ]]; then
+    echo "No - Full Disk Access not granted for Extension"
+    exit
+  fi;
+
+  if [[ $output != *"EDR status: enabled"* ]]; then
+    echo "No - EDR is not Enabled"
+    exit
+  fi;
+
+  if [[ $output != *"Preauthorization Status: granted"* ]]; then
+    echo "No - Preauthorization not granted"
+    exit
+  fi
+
+  echo "Yes"
+}
+
+# Checks the system extension status for the agent versions 0.14.32 and later
+check_status() {
+  output=$(/Applications/Huntress.app/Contents/MacOS/Huntress status)
+
+  if ! [[ $output =~ "Extension Status:.*installed" ]]; then
+    echo "No - Extension Not Installed";
+    exit
+  fi
+
+  if ! [[ $output =~ "Full Disk Access for Extension:.*true" ]]; then
+    echo "No - Full Disk Access not granted for Extension"
+    exit
+  fi;
+
+  if ! [[ $output =~ "EDR status:.*enabled" ]]; then
+    echo "No - EDR is not Enabled"
+    exit
+  fi;
+
+  if ! [[ $output =~ "Preauthorization Status:.*granted" ]]; then
+    echo "No - Preauthorization not granted"
+    exit
+  fi
+
+  echo "Yes"
+}
+
+agent_version=$(plutil -extract CFBundleVersion raw /Applications/Huntress.app/Contents/Info.plist)
+version_fields=( ${(s[.])agent_version} )
+
+if ((
+  $version_fields[1] > 0 ||
+    $version_fields[2] > 14 ||
+    ( $version_fields[2] == 14 && $version_fields[3] >= 32 )
+)); then
+  check_status
+else
+  check_legacy_status
 fi
-
-if [[ $output != *"Full Disk Access for Extension: enabled"* ]]; then
-  echo "No - Full Disk Access not granted for Extension"
-  exit
-fi;
-
-if [[ $output != *"EDR: enabled"* ]]; then
-  echo "No - EDR is not Enabled"
-  exit
-fi;
-
-if [[ $output != *"Preauthorization Status: granted"* ]]; then
-  echo "No - Preauthorization not granted"
-  exit
-fi
-
-echo "Yes"


### PR DESCRIPTION
**NOTE TO SELF: remember to upload this to `agent-deployment` repo too**

Updates the Addigy sysext.sh fact script to handle output from version 0.14.32 and later of the agent. To determine the agent version, we check the `CFBundleVersion` field in the `Info.plist` file within the Huntress app bundle.

Newer versions will call the new `Huntress status` command, and the script will also account for individual lines having a variable amount of whitespace between the field and value, rather than a single space as before:

```
# output from new status command

Huntress Agent Version:         0.14.56
Full Disk Access for Agent:     true
Extension Status:               installed
System Extension version:       0.0.97
Full Disk Access for Extension: true
EDR status:                     enabled
Preauthorization Status:        granted
Host Isolation Status:          notActivated

```

Older versions of the agent should continue to behave as before (i.e., running `Huntress extensionctl status` and parsing the output in its previous format).

```
# output from legacy command

Extension Status: installed
Full Disk Access for Extension: enabled
EDR status: enabled
Preauthorization Status: granted
Host Isolation Status: notActivated
```