### PR TITLE
Changed ScriptType to reflect Datto

### DIFF
--- a/Datto-RMM/scripts/InstallHuntress.dattormm.comstore.ps1
+++ b/Datto-RMM/scripts/InstallHuntress.dattormm.comstore.ps1
@@ -104,8 +104,8 @@ $estimatedSpaceNeeded = 200111222
 ##############################################################################
 
 # These are used by the Huntress support team when troubleshooting.
-$ScriptVersion = "Version 2, major revision 8, 2025 Apr 1"
-$ScriptType = "PowerShell"
+$ScriptVersion = "Version 2, major revision 8, 2025 Aug 1"
+$ScriptType = "PowerShell (Datto)"
 
 # variables used throughout this script
 $X64 = 64


### PR DESCRIPTION
This ScriptType should always be set to a unique value for each 3rd party system as Support needs a way to know which script was run in order to troubleshoot.