### PR TITLE
minor tweaks/fixes to registration behavior, reinstall flag, & logging 

### DIFF
--- a/Powershell/InstallHuntress.powershellv2.ps1
+++ b/Powershell/InstallHuntress.powershellv2.ps1
@@ -72,7 +72,7 @@ $estimatedSpaceNeeded = 200111222
 ##############################################################################
 
 # These are used by the Huntress support team when troubleshooting.
-$ScriptVersion = "Version 2, major revision 8, 2025 May 20"
+$ScriptVersion = "Version 2, major revision 8, 2025 Sept 16"
 $ScriptType = "PowerShell"
 
 # variables used throughout this script
@@ -434,7 +434,7 @@ function Test-Installation {
     $didAgentRegister = $false
     for ($i = 0; $i -le 40; $i++) {
         if (Test-Path "$($HuntressDirectory)\HuntressAgent.log") {
-            $linesFromLog = Get-Content "$($HuntressDirectory)\HuntressAgent.log" | Select-Object -first 4
+            $linesFromLog = Get-Content "$($HuntressDirectory)\HuntressAgent.log" | Select-Object -last 6
             ForEach ($line in $linesFromLog) {
                 if ($line -like "*registered agent*") {
                     LogMessage "Agent successfully registered in $($i/4) seconds"
@@ -446,12 +446,13 @@ function Test-Installation {
         }
         Start-Sleep -Milliseconds 250
     }
+    # If the agent didn't register, log the tail of HuntressAgent.log so Support can see the reason registration failed
     if ( ! $didAgentRegister) {
         $err = "WARNING: It does not appear the agent has successfully registered. Check 3rd party AV exclusion lists to ensure Huntress is excluded."
         LogMessage ($err + $SupportMessage)
         if (Test-Path "$($HuntressDirectory)\HuntressAgent.log") {
-            $linesFromLog = Get-Content "$($HuntressDirectory)\HuntressAgent.log" | Select-Object -first 4
-            LogMessage "Last 4 lines of HuntressAgent.log:"
+            $linesFromLog = Get-Content "$($HuntressDirectory)\HuntressAgent.log" | Select-Object -last 8
+            LogMessage "Newest 8 lines of HuntressAgent.log:"
             ForEach ($line in $linesFromLog) {
                 LogMessage $line
             }
@@ -963,8 +964,9 @@ function copyLogAndExit {
 # Sometimes previous installs can be stuck with services in the Disabled state, this function attempts to set the state to Automatic.
 # Services in the Disabled state cannot be manually started, and TP will stop partners from fixing this themselves. AB
 function fixServices {
+    $servicesOnInstall = @($HuntressAgentServiceName, $HuntressUpdaterServiceName)
     # Ensure the services are installed before repairing the state
-    foreach ($svc in $services) {
+    foreach ($svc in $servicesOnInstall) {
         if (  (Confirm-ServiceExists($svc))) {
             # repairing service state
             if ( $(Get-Service $svc).StartType -ne "automatic") {
@@ -1092,8 +1094,8 @@ function main () {
     }
 
     # reregister > reinstall > uninstall > install (in decreasing order of impact)
-    # reregister = reinstall + delete registry keys
-    # reinstall  = install + stop Huntress service
+    # reregister = reinstall + delete registry keys 
+    # reinstall  = stop Huntress service + reinstall
     if ($reregister) {
         LogMessage "Re-register agent: '$reregister'"
         if ( !(Confirm-ServiceExists($HuntressAgentServiceName))) {
@@ -1106,15 +1108,18 @@ function main () {
             $err = "Script was run w/ reinstall flag but there's nothing to reinstall. Attempting to clean remnants, then install the agent fresh."
             LogMessage "$err"
             uninstallHuntress
-            copyLogAndExit
         }
         StopHuntressServices
     } else {
         LogMessage "Checking for HuntressAgent install..."
         $agentPath = getAgentPath
         if ( (Test-Path $agentPath) -eq $true) {
-            LogMessage "The Huntress Agent is already installed in $agentPath. Exiting with no changes. Suggest using -reregister or -reinstall flags"
-            copyLogAndExit
+            $assets = Get-ChildItem -path $agentPath -file
+            # to avoid issues with a single file blocking installs, only exit script if multiple files are found and script not run with -reregister or -reinstall
+            if ($assets.count -ge 2) {
+              LogMessage "The Huntress Agent is already installed in $agentPath. Exiting with no changes. Suggest using -reregister or -reinstall flags"
+              copyLogAndExit
+            }
         }
     }
 


### PR DESCRIPTION
* HuntressAgent.log has grown so the existing tail of that log was not being captured accurately. Tailing 6 now instead of first'ing 4. This tail is used to determine if the agent registered.
* Tweaked unsuccessful registration event to tail the last 8 lines of HuntressAgent.log to try to capture more usable data (again because that log has grown). This helps Support find issues quicker and with less effort required by the partner.
* The fixServices function was incorrectly looking for Rio, checking for the service first was sometimes throwing errors. Re-scoped to just Huntress agent and updater services being checked post-install.
* The -reinstall flag was exiting after uninstall instead of proceeding with the install.
* Change in behavior: previously if the Huntress folder was found the installer would exit (to prevent RMM's from hammering a machine). Now if only 1 file is found it will continue with install. This is to get around cases where a single log file was blocking installs.