### PR TITLE
Continuum: honor supplied Organization Key, keep account key out of logs

### DIFF
--- a/Continuum/InstallHuntress.continuum.ps1
+++ b/Continuum/InstallHuntress.continuum.ps1
@@ -46,6 +46,22 @@ param (
 # Replace __ACCOUNT_KEY__ with your account secret key.
 $AccountKey = "__ACCOUNT_KEY__"
 
+# Optional. Leave this line unmodified to derive the Organization Key from the
+# SITEID/SITENAME registry values, which is the default behavior.
+#
+# ConnectWise RMM users: ConnectWise no longer populates SITENAME, so the
+# default naming produces Organizations named after the numeric Site ID. The
+# RMM does expose the site name to the script as a built-in variable, so you
+# can name Organizations after the client instead by setting this line to:
+#
+#     $OrganizationKey = "%sitename%"
+#
+# Note that ConnectWise uses two different delimiters: task parameters you
+# define yourself use @Name@ (for example @Account_Key@ above), while built-in
+# variables such as sitename and output use %Name%. Using the wrong delimiter
+# leaves the token in place as literal text.
+$OrganizationKey = "__ORGANIZATION_KEY__"
+
 # Set to "Continue" to enable verbose logging.
 $DebugPreference = "SilentlyContinue"
 
@@ -77,6 +93,9 @@ $InstallerName = "HuntressInstaller.exe"
 $InstallerPath = Join-Path $Env:TMP $InstallerName
 $DebugLog = Join-Path $Env:TMP HuntressInstaller.log
 $DownloadURL = "https://update.huntress.io/download/" + $AccountKey + "/" + $InstallerName
+# The download URL embeds the account key. Log this redacted copy instead, so
+# the key is not written into RMM task output where it is broadly readable.
+$SafeDownloadURL = "https://update.huntress.io/download/<account key redacted>/" + $InstallerName
 $HuntressAgentServiceName = "HuntressAgent"
 $HuntressUpdaterServiceName = "HuntressUpdater"
 
@@ -332,7 +351,7 @@ function Get-Installer {
     } catch {
         $msg = $_.Exception.Message
         $err = (
-            "ERROR: Failed to download the Huntress Installer. Please try accessing $DownloadURL " +
+            "ERROR: Failed to download the Huntress Installer. Please try accessing $SafeDownloadURL " +
             "from a web browser on the host where the download failed. If the issue persists, please " +
             "send the error message to the Huntress Team for help at support@huntress.com.")
         LogMessage $msg
@@ -341,7 +360,7 @@ function Get-Installer {
     }
 
     if ( ! (Test-Path $InstallerPath) ) {
-        $err = "ERROR: Failed to download the Huntress Installer from $DownloadURL."
+        $err = "ERROR: Failed to download the Huntress Installer from $SafeDownloadURL."
         LogMessage $err
         LogMessage $SupportMessage
         throw $ScriptFailed + " " + $err + " " + $SupportMessage
@@ -369,7 +388,10 @@ function Install-Huntress ($OrganizationKey) {
     $msg = "Executing installer..."
     LogMessage $msg
 
-    $timeout = 30 # Seconds
+    # Matches the timeout used by InstallHuntress.powershellv2.ps1. Third party
+    # security software can slow the install considerably when the Huntress
+    # exclusions are not in place, and 30 seconds is not always enough.
+    $timeout = 120 # Seconds
     $process = Start-Process $InstallerPath "/ACCT_KEY=`"$AccountKey`" /ORG_KEY=`"$OrganizationKey`" /S" -PassThru
     try {
         $process | Wait-Process -Timeout $timeout -ErrorAction Stop
@@ -517,8 +539,20 @@ function main () {
     LogMessage "Installer location: '$InstallerPath'"
     LogMessage "Installer log: '$DebugLog'"
 
-    # Continuum specific
-    $OrganizationKey = Get-OrganizationKey
+    # Continuum specific.
+    # Only derive the Organization Key from the registry when one was not
+    # supplied. Previously this assignment was unconditional, so both the
+    # -orgkey parameter and the $OrganizationKey variable above were silently
+    # discarded.
+    # The placeholder is matched by shape rather than by its literal text. If
+    # this compared against the placeholder directly, a user who did a global
+    # find and replace on it would turn the comparison into "is the key equal
+    # to itself", silently disabling the override again.
+    if ( [string]::IsNullOrEmpty($OrganizationKey) -or ($OrganizationKey -match '^__.+__$') ) {
+        $OrganizationKey = Get-OrganizationKey
+    } else {
+        LogMessage "Using the supplied Organization Key."
+    }
 
     # trim keys before use
     $AccountKey = $AccountKey.Trim()


### PR DESCRIPTION
Four fixes to the Continuum script, found while deploying it through ConnectWise RMM today. Each was reproduced before and after the change; details below.

## 1. The Organization Key could never be overridden

`main()` assigned `$OrganizationKey = Get-OrganizationKey` unconditionally, and it ran *after* the `-orgkey` parameter was applied at the top of the script. Anything supplied was overwritten before it was ever used, so the documented `-orgkey` parameter silently did nothing and the registry value always won.

Related: `Test-Parameters` checks `if ($OrganizationKey -eq "__ORGANIZATION_KEY__")`, but no such placeholder was ever assigned anywhere in the file, so that branch was unreachable. This PR adds the placeholder variable, which makes the existing check meaningful and brings the file in line with `InstallHuntress.powershellv2.ps1`.

The new guard matches the placeholder by *shape* (`^__.+__$`) rather than by its literal text. Comparing against the literal is a trap: a user who does a global find-and-replace on `__ORGANIZATION_KEY__` turns the comparison into "is the key equal to itself", which silently re-disables the override. Matching by shape survives that.

## 2. The account key was written into RMM logs

`$DownloadURL` embeds the account key:

```
https://update.huntress.io/download/<account key>/HuntressInstaller.exe
```

Both download-failure paths interpolated it into the log message. In an RMM this lands in the task output, which is readable by anyone with script access, and it fires on any wrong key or transient network fault. Those two messages now use a redacted copy. The real URL is of course still used for the download itself.

## 3. Installer timeout raised from 30s to 120s

`InstallHuntress.powershellv2.ps1` already uses 120, with the note that third party AV/EDR can significantly slow the install when the Huntress exclusions are not in place. The Continuum script still used 30. A healthy laptop installs in about 8 seconds, but 30 seconds is not much headroom on an older or busy endpoint running another security agent.

## 4. Documented the ConnectWise RMM site-name option

The ConnectWise RMM article notes that ConnectWise stopped populating `SITENAME`, so Organizations end up named after the numeric Site ID and have to be renamed by hand in the Huntress portal.

`SITENAME` is indeed gone from the registry, but the RMM exposes the site name to the script directly as a built-in variable, so this works:

```powershell
$OrganizationKey = "%sitename%"
```

This is worth documenting because it also covers sites created natively in Asio, which have no Continuum Site ID at all and which the registry path therefore cannot identify.

The delimiter is the part that is easy to get wrong, and it is why this is not obvious: **ConnectWise uses two different ones.** Parameters you define use `@Name@`, while built-in variables use `%Name%`. Confirmed on a live run, where `@sitename@` came through as literal text while `%sitename%` resolved to the client name. This is also why the KB has you put `%output%` in the Script Log row. Parameter names are matched case-insensitively but underscores matter: `@ACCOUNT_KEY@` and `@account_key@` both resolved, `@AccountKey@` did not.

## Verification

Run against a live ConnectWise RMM endpoint and locally with a placeholder key:

| Case | Result |
| --- | --- |
| Untouched script | Organization Key from registry SITEID (unchanged behavior) |
| `-orgkey "Test Client Name"` | Honored (previously discarded) |
| `$OrganizationKey` edited in file | Honored |
| Global find-and-replace of the placeholder | Honored |
| Download failure | Account key no longer appears in the log |

Behavior is unchanged for anyone who does not set an Organization Key.

## Two notes on the KB article, not addressed here

- The Option 2 snippet in [Install via ConnectWise RMM](https://support.huntress.io/hc/en-us/articles/4404012779923-Install-via-ConnectWise-RMM) is rendered with curly quotes (`[string]$acctkey=”@Account_Key@”`). PowerShell does not accept those as string delimiters, so copying that block produces a script that will not parse.
- The same article's Option 1 instructions do not mention the `@Name@` versus `%Name%` distinction, which makes the `Organization_Key` and `Tags` guidance hard to follow.

Happy to split this into separate PRs, drop any individual change, or adjust the wording of the comments if you would prefer them shorter.
